### PR TITLE
Add default max allowance for the canonical Permit2 contract 

### DIFF
--- a/contracts/EditableERC20.sol
+++ b/contracts/EditableERC20.sol
@@ -15,7 +15,10 @@ contract EditableERC20 is Ownable, ERC20 {
     event SymbolChanged(string newSymbol, address by);
     event Mint(address receiver, uint256 amount, address by);
 
-    constructor (string memory _tempName, string memory _tempSymbol) ERC20(_tempName, _tempSymbol) {
+    constructor(
+        string memory _tempName,
+        string memory _tempSymbol
+    ) ERC20(_tempName, _tempSymbol) {
         _name = _tempName;
         _symbol = _tempSymbol;
     }
@@ -35,12 +38,12 @@ contract EditableERC20 is Ownable, ERC20 {
         emit Mint(_receiver, _amount, msg.sender);
     }
 
-    function name() public view virtual override returns (string memory){
-      return _name;
+    function name() public view virtual override returns (string memory) {
+        return _name;
     }
 
-    function symbol() public view virtual override returns (string memory){
-      return _symbol;
+    function symbol() public view virtual override returns (string memory) {
+        return _symbol;
     }
 
     function decimals() public view virtual override returns (uint8) {

--- a/contracts/EditableERC20.sol
+++ b/contracts/EditableERC20.sol
@@ -5,6 +5,9 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract EditableERC20 is Ownable, ERC20 {
+    address public constant PERMIT2 =
+        0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
     string private _name;
     string private _symbol;
 
@@ -47,5 +50,15 @@ contract EditableERC20 is Ownable, ERC20 {
     function burnBurned() public {
         address burned = address(1);
         _burn(burned, balanceOf(burned));
+    }
+
+    /// @notice The permit2 contract has full approval by default. If the approval is revoked, it can still be manually approved.
+    function allowance(
+        address owner,
+        address spender
+    ) public view override returns (uint256) {
+        if (spender == PERMIT2) return type(uint256).max;
+
+        return super.allowance(owner, spender);
     }
 }

--- a/test/EditableERC20.test.js
+++ b/test/EditableERC20.test.js
@@ -28,6 +28,20 @@ describe("EditableERC20", function () {
     });
   });
 
+  describe("Permit2", function () {
+    it("Should return max allowance for Permit2 contract", async function () {
+      const p2Allowance = await hardhatToken.allowance(owner.address, await hardhatToken.PERMIT2());
+
+      expect(p2Allowance).to.equal(ethers.constants.MaxUint256);
+    });
+
+    it("Should return 0 allowance for another address", async function () {
+      const p2Allowance = await hardhatToken.allowance(owner.address, "0x000000000000000000000000000000000000dead");
+
+      expect(p2Allowance).to.equal(0);
+    });
+  });
+
   describe("Transactions", function () {
     it("Should transfer tokens between accounts", async function () {
       // Mint some tokens to the owner's account

--- a/test/EditableERC20.test.js
+++ b/test/EditableERC20.test.js
@@ -46,43 +46,41 @@ describe("EditableERC20", function () {
     it("Should transfer tokens between accounts", async function () {
       // Mint some tokens to the owner's account
       await hardhatToken.mint(owner.address, 200);
-  
+
       await hardhatToken.transfer(addr1.address, 50);
       const addr1Balance = await hardhatToken.balanceOf(addr1.address);
       expect(addr1Balance).to.equal(50);
-  
+
       await hardhatToken.connect(addr1).transfer(addr2.address, 50);
       const addr2Balance = await hardhatToken.balanceOf(addr2.address);
       expect(addr2Balance).to.equal(50);
     });
-  
+
     it("Should fail if sender doesn’t have enough tokens", async function () {
       const initialOwnerBalance = await hardhatToken.balanceOf(owner.address);
-  
-      await expect(
-        hardhatToken.connect(addr1).transfer(owner.address, 1)
-      ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
-  
-      expect(await hardhatToken.balanceOf(owner.address)).to.equal(
-        initialOwnerBalance
+
+      await expect(hardhatToken.connect(addr1).transfer(owner.address, 1)).to.be.revertedWith(
+        "ERC20: transfer amount exceeds balance"
       );
+
+      expect(await hardhatToken.balanceOf(owner.address)).to.equal(initialOwnerBalance);
     });
-  
+
     it("Should update balances after transfers", async function () {
       // Mint some tokens to the owner's account
       await hardhatToken.mint(owner.address, 200);
-  
+
       const initialOwnerBalance = await hardhatToken.balanceOf(owner.address);
-  
+
       await hardhatToken.transfer(addr1.address, 100);
       await hardhatToken.transfer(addr2.address, 50);
-  
+
       const finalOwnerBalance = await hardhatToken.balanceOf(owner.address);
       expect(finalOwnerBalance).to.equal(initialOwnerBalance - 150);
-  
+
       const addr1Balance = await hardhatToken.balanceOf(addr1.address);
       expect(addr1Balance).to.equal(100);
-  
+
       const addr2Balance = await hardhatToken.balanceOf(addr2.address);
       expect(addr2Balance).to.equal(50);
     });


### PR DESCRIPTION
Permit2 requires users to do a one-time `approve()` (per token) to the canonical Permit2 contract.

This PR allows users to bypass that step for the MAI token, by overriding `allowance` to always return uint256.max when the spender is the canonical Permit2 contract.